### PR TITLE
メッセージの非同期通信化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,7 +35,7 @@ $(document).on('turbolinks:load', function() {
     .done(function(data){
       var html = buildHTML(data);
       $('.messages').append(html);
-      $('#message_content').val(''); 
+      $('#new_message')[0].reset();
     })
     .fail(function(data){
       alert('エラーが発生したためメッセージは送信できませんでした。');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,55 @@
+$(document).on('turbolinks:load', function() {
+  function buildHTML(message) {
+    var content = message.content ? `${ message.content }` : "";
+    var img = message.image ? `<img src= ${ message.image }>` : "";
+    var html = `<div class="message" data-id="${message.id}">
+                  <div class="message__upper-info">
+                    <p class="message__upper-info__talker">
+                      ${message.user_name}
+                    </p>
+                    <p class="message__upper-info__date">
+                      ${message.date}
+                    </p>
+                  </div>
+                  <p class="message__upper-info__text">
+                    <div>
+                    ${content}
+                    </div>
+                    ${img}
+                  </p>
+                </div>`
+  return html;
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var message = new FormData(this); 
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: message,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('#message_content').val(''); 
+    })
+    .fail(function(data){
+      alert('エラーが発生したためメッセージは送信できませんでした。');
+    })
+    .always(function(data){
+      $('.submit-btn').prop('disabled', false);
+    })
+    .done(function scrollBottom(){
+      var target = $('.message').last();
+      var position = target.offset().top + $('.messages').scrollTop();
+      $('.messages').animate({
+        scrollTop: position
+      }, 300, 'swing');
+    })
+  })
+});
+

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create  
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to "group_messages_path(params[:group_id])" }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.id      @message.id
+json.content @message.content 
+json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name @message.user.name
+json.image   @message.image.url


### PR DESCRIPTION
### WHAT
jsファイルを作成する
フォームが送信されたら、イベントが発火するようにする
イベントが発火したときにAjaxを使用して、messages#createが動くようにする
messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
jbuilderを使用して、作成したメッセージをJSON形式で返す
返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
作成したHTMLをメッセージ画面の一番下に追加する
HTMLを追加した分、メッセージ画面を下にスクロールする
連続で送信ボタンを押せるようにする
非同期に失敗した場合の処理も準備する

https://i.gyazo.com/48d5ba4164200f692d404d2eadbe91f3.mp4

### WHY

メッセージ送信の際にの非同期通信化を行うため